### PR TITLE
hide status bar item when no CODEOWNERS file

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -15,7 +15,13 @@ const getOwners = () => {
         uri: { fsPath: workspacePath }
     } = vscode.workspace.getWorkspaceFolder(uri);
 
-    const folder = new Codeowners(workspacePath);
+    let folder;
+    try {
+        folder = new Codeowners(workspacePath);
+    } catch {
+        // no CODEOWNERS file
+        return null;
+    }
 
     const file = fileName.split(workspacePath)[1];
 
@@ -39,6 +45,11 @@ const activate = context => {
     context.subscriptions.push(
         vscode.window.onDidChangeActiveTextEditor(() => {
             const owners = getOwners();
+
+            if (!owners) {
+                statusBarItem.hide();
+                return;
+            }
 
             if (owners.length > 2) {
                 statusBarItem.text = `CODEOWNERS: ${owners[0]} & ${owners.length - 1} others`;


### PR DESCRIPTION
If:
- you have a multi-root workspace
- one workspace has CODEOWNERS, the other doesn't

Then when you switch to the one that doesn't, the status bar item will
remain and give incorrect information.

Fix this by hiding the status bar item when there is no CODEOWNERS file
nearby.

## Before
![Peek 2019-06-22 01-31](https://user-images.githubusercontent.com/3344958/59969730-c393d300-9509-11e9-852a-5b543075e129.gif)

## After
![Peek 2019-06-22 01-33](https://user-images.githubusercontent.com/3344958/59969733-c7bff080-9509-11e9-98e0-e7627fcecdc8.gif)
