### PR TITLE
Make CODEOWNERS file name configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,13 @@ The first code owners for an open file will be displayed in the right side of th
 ![](./img/command.gif)
 
 Use the command palette to run the `CODEOWNERS: Show owners of current file` command, which will display all code owners for the current file.
+
+
+## Modify CODEOWNERS file name
+
+You can modify the default CODEOWNERS file name to any custom name which your project uses:
+```json
+{
+    "codeowners.fileName": "MY_CUSTOM_CODEOWNERS"
+}
+```

--- a/extension.js
+++ b/extension.js
@@ -5,6 +5,12 @@ const path = require('path');
 const COMMAND_ID = 'vscode-codeowners.show-owners';
 const STATUS_BAR_PRIORITY = 100;
 
+// Function to get the custom CODEOWNERS file name or default to "CODEOWNERS"
+const getCodeownersFileName = () => {
+    const config = vscode.workspace.getConfiguration('codeowners');
+    return config.fileName || 'CODEOWNERS';
+};
+
 const getOwners = () => {
     if (!vscode.window.activeTextEditor) {
         return [];
@@ -18,7 +24,8 @@ const getOwners = () => {
 
     let folder;
     try {
-        folder = new Codeowners(workspacePath);
+        const codeownersFileName = getCodeownersFileName(); // Use the custom or default file name
+        folder = new Codeowners(path.join(workspacePath, '.github'), codeownersFileName); // Assuming CODEOWNERS is in the .github folder
     } catch {
         // no CODEOWNERS file
         return null;
@@ -70,5 +77,5 @@ const activate = context => {
 
 exports.activate = activate;
 
-const deactivate = () => {};
+const deactivate = () => { };
 exports.deactivate = deactivate;


### PR DESCRIPTION
## Modify CODEOWNERS file name

You can modify the default CODEOWNERS file name to any custom name which your project uses:
```json
{
    "codeowners.fileName": "MY_CUSTOM_CODEOWNERS"
}
```